### PR TITLE
fix(control): reading refresh_token from cookie

### DIFF
--- a/platform/control/routers/usersRouter.py
+++ b/platform/control/routers/usersRouter.py
@@ -94,7 +94,7 @@ async def login(data: usersSchema.LoginSchema):
       secure=True,
       httponly=True,
       samesite="lax",
-      path="/api/auth/refresh",
+      path="/auth/refresh",
     )
   )
 

--- a/platform/control/schemas/authSchema.py
+++ b/platform/control/schemas/authSchema.py
@@ -1,5 +1,0 @@
-from pydantic import BaseModel
-
-
-class RefreshTokenSchema(BaseModel):
-  refresh_token: str


### PR DESCRIPTION
## Changes
- The renewal endpoint now take the `refresh_token` from the Cookie Header

Resolves #34