### PR TITLE
fix(control): Fixed cookie path and made secure to true only on production

### DIFF
--- a/platform/control/routers/authRouter.py
+++ b/platform/control/routers/authRouter.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Cookie
 from services import refresh_token
 from utils.status import Response, HTTPStatus
 from datetime import datetime, timezone
+from core import debug
 
 
 router = APIRouter(prefix="/auth", tags=["Authentication"])
@@ -32,7 +33,7 @@ async def refresh(token: str | None = Cookie(default=None, alias="refresh_token"
       expires=datetime.fromtimestamp(
         timestamp=jwt.access_token.expiry_time(), tz=timezone.utc
       ),
-      secure=True,
+      secure=not debug.DEBUG,
       httponly=True,
       samesite="lax",
       path="/",
@@ -43,9 +44,9 @@ async def refresh(token: str | None = Cookie(default=None, alias="refresh_token"
       expires=datetime.fromtimestamp(
         timestamp=jwt.refresh_token.expiry_time(), tz=timezone.utc
       ),
-      secure=True,
+      secure=not debug.DEBUG,
       httponly=True,
       samesite="lax",
-      path="/api/auth/refresh",
+      path="/auth/refresh",
     )
   )

--- a/platform/control/routers/usersRouter.py
+++ b/platform/control/routers/usersRouter.py
@@ -9,6 +9,7 @@ from services.logout import logout_user
 from services import exceptions
 from utils.status import Response, HTTPStatus
 from datetime import datetime, timezone
+from core import debug
 
 
 router = APIRouter(prefix="/users", tags=["Users"])
@@ -82,7 +83,7 @@ async def login(data: usersSchema.LoginSchema):
       expires=datetime.fromtimestamp(
         timestamp=jwt.access_token.expiry_time(), tz=timezone.utc
       ),
-      secure=True,
+      secure=not debug.DEBUG,
       httponly=True,
       samesite="lax",
       path="/",
@@ -93,7 +94,7 @@ async def login(data: usersSchema.LoginSchema):
       expires=datetime.fromtimestamp(
         timestamp=jwt.refresh_token.expiry_time(), tz=timezone.utc
       ),
-      secure=True,
+      secure=not debug.DEBUG,
       httponly=True,
       samesite="lax",
       path="/auth/refresh",


### PR DESCRIPTION
## Changes
- Fixed bug of `refresh_token` cookie is not saving in the `/auth/refresh` path on renewal
- Made the secure flag to make it true only on production, not in development environment

Resolves #43 